### PR TITLE
Flat Renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # HEAD
-
+- Implement `Pigment` types and rudimental `BRDF` methods
+- Implement `Flat` renderer
 # Version 0.2.1
 
 ## Bugfixes

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ julia main.jl <pfm_file> <a> <gamma> <output_file>
 ```
 
 ### Demo version
-A demo scene is provided with the `demo.jl` script. The scene is composed by 8 spheres positioned on the edges of a cube, and 2 spheres placed in the middle of two adiacent faces.
+A demo scene is provided with the `demo.jl` script. The scene is composed by 8 spheres with a uniform pigment positioned on the edges of a cube, and 2 checkered spheres placed in the middle of two adiacent faces.
 The user must provide the output filename, which will be used to saved the output image in both `.pfm` and `.png` formats, the width and height of the image and the camera angle.
 ```bash
 julia demo.jl <output_file> <width> <height> <cam_angle>

--- a/demo.jl
+++ b/demo.jl
@@ -16,18 +16,24 @@ function demo()
     pfm_output = ARGS[1]*".pfm"
 
     Sc = Scaling(1.0 / 10.0, 1.0 / 10.0, 1.0 / 10.0)
+    
+    color1 = RGB(0.7, 0.3, 1.0)
+    color2 = RGB(0.9, 0.8, 0.7)
+    colol3 = RGB(0.1, 0.2, 0.3)
+    Mat1 = Material(UniformPigment(color1), DiffusiveBRDF(UniformPigment(color1), 0.5))
+    Mat2 = Material(CheckeredPigment(4, 4, color1, color2), DiffusiveBRDF(UniformPigment(color1), 0.5))
 
     S = Vector{Shape}(undef, 10)
-    S[1] = Sphere(Translation(0.5, 0.5, 0.5) ⊙ Sc)
-    S[2] = Sphere(Translation(-0.5, 0.5, 0.5) ⊙ Sc)
-    S[3] = Sphere(Translation(0.5, -0.5, 0.5) ⊙ Sc)
-    S[4] = Sphere(Translation(0.5, 0.5, -0.5) ⊙ Sc)
-    S[5] = Sphere(Translation(0.5, -0.5, -0.5) ⊙ Sc)
-    S[6] = Sphere(Translation(-0.5, 0.5, -0.5) ⊙ Sc)
-    S[7] = Sphere(Translation(-0.5, -0.5, 0.5) ⊙ Sc)
-    S[8] = Sphere(Translation(-0.5, -0.5, -0.5) ⊙ Sc)
-    S[9] = Sphere(Translation(0.0, 0.0, -0.5) ⊙ Sc)
-    S[10] = Sphere(Translation(0.0, 0.5, 0.0) ⊙ Sc)
+    S[1] = Sphere(Translation(0.5, 0.5, 0.5) ⊙ Sc, Mat1)
+    S[2] = Sphere(Translation(-0.5, 0.5, 0.5) ⊙ Sc, Mat1)
+    S[3] = Sphere(Translation(0.5, -0.5, 0.5) ⊙ Sc, Mat1)
+    S[4] = Sphere(Translation(0.5, 0.5, -0.5) ⊙ Sc, Mat1)
+    S[5] = Sphere(Translation(0.5, -0.5, -0.5) ⊙ Sc, Mat1)
+    S[6] = Sphere(Translation(-0.5, 0.5, -0.5) ⊙ Sc, Mat1)
+    S[7] = Sphere(Translation(-0.5, -0.5, 0.5) ⊙ Sc, Mat1)
+    S[8] = Sphere(Translation(-0.5, -0.5, -0.5) ⊙ Sc, Mat1)
+    S[9] = Sphere(Translation(0.0, 0.0, -0.5) ⊙ Sc, Mat2)
+    S[10] = Sphere(Translation(0.0, 0.5, 0.0) ⊙ Sc, Mat2)
 
     R_cam = Rz(cam_angle)
     world = World(S)
@@ -35,20 +41,15 @@ function demo()
     hdr = hdrimg(width, height)
     ImgTr = ImageTracer(hdr, cam)
 
-    function delta(ray)
+    function flat(ray)
         repo = ray_interception(world, ray)
-
-        if isnothing(repo)
-            return RGB(0.0, 0.0, 0.0)
-        else
-            return RGB(1.0, 1.0, 1.0)
-        end
+        return (isnothing(repo)) ? RGB(0.0, 0.0, 0.0) : repo.shape.Mat.Emition(repo.surface_P)
     end
 
-    ImgTr(delta)
+    ImgTr(flat)
 
     println("Saving image in ", png_output)
-    toned_img = tone_mapping(hdr; a=0.18, γ=2.2)
+    toned_img = tone_mapping(hdr; a = 0.5, lum = 0.5, γ = 1.3)
     # Save the LDR image
     save_ldrimage(get_matrix(toned_img), png_output)
     println("Saved image in ", png_output)

--- a/demo.jl
+++ b/demo.jl
@@ -41,10 +41,7 @@ function demo()
     hdr = hdrimg(width, height)
     ImgTr = ImageTracer(hdr, cam)
 
-    function flat(ray)
-        repo = ray_interception(world, ray)
-        return (isnothing(repo)) ? RGB(0.0, 0.0, 0.0) : repo.shape.Mat.Emition(repo.surface_P)
-    end
+    flat = Flat(world)
 
     ImgTr(flat)
 

--- a/src/brdf.jl
+++ b/src/brdf.jl
@@ -1,13 +1,4 @@
 #---------------------------------------------------------
-# Matherial
-#---------------------------------------------------------
-
-struct Material
-    Emition::AbstractPigment
-    BRDF::AbstractBRDF
-end
-
-#---------------------------------------------------------
 # Pigment
 #---------------------------------------------------------
 
@@ -35,9 +26,6 @@ struct UniformPigment <: AbstractPigment
     end
 end
 
-function (U::UniformPigment)(p::SurfacePoint)
-    return U.color
-end
 
 """
     CheckeredPigment(col::Int32, row::Int32, dark::RGB, bright::RGB)
@@ -59,12 +47,6 @@ struct CheckeredPigment <: AbstractPigment
     bright::RGB
 end
 
-function (C::CheckeredPigment)(p::SurfacePoint)
-    x = Int32(p.u * col)
-    y = Int32(p.v * row)
-
-    return ((x + y) % 2 == 0) ? C.dark : C.bright
-end
 
 """
     ImagePigment(img::hdrimg)
@@ -77,13 +59,6 @@ Print the image `img` as pigment of the surface
 """
 struct ImagePigment <: AbstractPigment
     img::hdrimg
-end
-
-function (I::ImagePigment)(p::SurfacePoint)
-    x = Int32(p.u * I.img.w)
-    y = Int32(p.v * I.img.h)
-
-    return I.img[x, y]
 end
 
 #---------------------------------------------------------
@@ -102,11 +77,13 @@ struct DiffusiveBRDF <: AbstractBRDF
     R::Float64
 end
 
-"""
-    Eval(BRDF::DiffusiveBRDF, normal::Normal, in_dir::Vec, out_dir::Vec, p::SurfacePoint)
+# Eval method inside shape.jl
 
-Return color of the diffused ray regarldless its icoming or outcoming direction
-"""
-function Eval(BRDF::DiffusiveBRDF, normal::Normal, in_dir::Vec, out_dir::Vec, p::SurfacePoint)
-    return BRDF.Pigment(p) * BRDF.R / π
-end 
+#---------------------------------------------------------
+# Material
+#---------------------------------------------------------
+
+struct Material
+    Emition::AbstractPigment
+    BRDF::AbstractBRDF
+end

--- a/src/brdf.jl
+++ b/src/brdf.jl
@@ -1,4 +1,13 @@
 #---------------------------------------------------------
+# Matherial
+#---------------------------------------------------------
+
+struct Material
+    Emition::AbstractPigment
+    BRDF::AbstractBRDF
+end
+
+#---------------------------------------------------------
 # Pigment
 #---------------------------------------------------------
 
@@ -8,6 +17,11 @@ abstract type AbstractPigment end
     UniformPigment()
 
 Uniform Pigment for Shapes
+# Fields
+- `color::RBG` the uniform color
+
+# Functional Usage
+`UniformPigment(p::SurfacePoint)` return the `RGB` associated to the `(u, v)` coordinates of the `SurfacePoint`
 """
 struct UniformPigment <: AbstractPigment
     color::RGB
@@ -21,14 +35,58 @@ struct UniformPigment <: AbstractPigment
     end
 end
 
+function (U::UniformPigment)(p::SurfacePoint)
+    return U.color
+end
+
 """
-    CheckeredPigment(row::Int32, col::Int32, dark::RGB, bright::RGB)
+    CheckeredPigment(col::Int32, row::Int32, dark::RGB, bright::RGB)
 
 Checkered pigment for a Shape, subdiveded in `row` rows and `col` columns with alternate `dark` and `bright` color
+# Fields
+- `col` number of horizontal subdivisions
+- `row` number of vertical subdivisions
+- `dark` color of the dark squares
+- `bright` color of the bright squares
+
+# Functional Usage
+`CheckeredPigment(p::SurfacePoint)` return the `RGB` associated to the `(u, v)` coordinates of the `SurfacePoint` 
 """
 struct CheckeredPigment <: AbstractPigment
-    row::Int32
     col::Int32
+    row::Int32
     dark::RGB
     bright::RGB
 end
+
+function (C::CheckeredPigment)(p::SurfacePoint)
+    x::Int32 = p.u * col
+    y::Int32 = p.v * row
+
+    return ((x + y) % 2 == 0) ? C.dark : C.bright
+end
+
+#---------------------------------------------------------
+# BRDF
+#---------------------------------------------------------
+
+abstract type AbstractBRDF end
+
+"""
+    DiffusiveBRDF(Pigment::AbstractPigment, R::Float64)
+
+Diffusive BRDF with reflective pigment `Pigment` and refelectance `R`
+"""
+struct DiffusiveBRDF <: AbstractBRDF
+    Pigment::AbstractPigment
+    R::Float64
+end
+
+"""
+    Eval(BRDF::DiffusiveBRDF, normal::Normal, in_dir::Vec, out_dir::Vec, p::SurfacePoint)
+
+Return color of the diffused ray regarldless its icoming or outcoming direction
+"""
+function Eval(BRDF::DiffusiveBRDF, normal::Normal, in_dir::Vec, out_dir::Vec, p::SurfacePoint)
+    return BRDF.Pigment(p) * BRDF.R / π
+end 

--- a/src/brdf.jl
+++ b/src/brdf.jl
@@ -1,0 +1,34 @@
+#---------------------------------------------------------
+# Pigment
+#---------------------------------------------------------
+
+abstract type AbstractPigment end
+
+"""
+    UniformPigment()
+
+Uniform Pigment for Shapes
+"""
+struct UniformPigment <: AbstractPigment
+    color::RGB
+
+    function UniformPigment(color::RGB)
+        new(color)
+    end
+
+    function UniformPigment()
+        new(RGB(1.0, 1.0, 1.0))
+    end
+end
+
+"""
+    CheckeredPigment(row::Int32, col::Int32, dark::RGB, bright::RGB)
+
+Checkered pigment for a Shape, subdiveded in `row` rows and `col` columns with alternate `dark` and `bright` color
+"""
+struct CheckeredPigment <: AbstractPigment
+    row::Int32
+    col::Int32
+    dark::RGB
+    bright::RGB
+end

--- a/src/brdf.jl
+++ b/src/brdf.jl
@@ -60,10 +60,30 @@ struct CheckeredPigment <: AbstractPigment
 end
 
 function (C::CheckeredPigment)(p::SurfacePoint)
-    x::Int32 = p.u * col
-    y::Int32 = p.v * row
+    x = Int32(p.u * col)
+    y = Int32(p.v * row)
 
     return ((x + y) % 2 == 0) ? C.dark : C.bright
+end
+
+"""
+    ImagePigment(img::hdrimg)
+
+Print the image `img` as pigment of the surface
+# Fields
+- `img::hdrimg` the image in hdr format
+# Functional Usage
+`ImagePigment(p::SurfacePoint)` return the `RGB` of to the `(u, v)` coordinates of the `SurfacePoint` associated to the corresponding element of `img`
+"""
+struct ImagePigment <: AbstractPigment
+    img::hdrimg
+end
+
+function (I::ImagePigment)(p::SurfacePoint)
+    x = Int32(p.u * I.img.w)
+    y = Int32(p.v * I.img.h)
+
+    return I.img[x, y]
 end
 
 #---------------------------------------------------------

--- a/src/jujutracer.jl
+++ b/src/jujutracer.jl
@@ -32,10 +32,10 @@ export Ray, AbstractCamera, Orthogonal, Perspective
 include("imagetracer.jl")
 export ImageTracer
 
-include("shapes.jl")
-export SurfacePoint, HitRecord, Shape, Sphere, ray_interception, Plane, World
-
 include("brdf.jl")
-export Material, UniformPigment, CheckeredPigment, ImagePigment, DiffusiveBRDF, Eval
+export UniformPigment, CheckeredPigment, ImagePigment, DiffusiveBRDF, Material
+
+include("shapes.jl")
+export SurfacePoint, HitRecord, Shape, Sphere, ray_interception, Plane, World, Eval
 
 end # module jujutracer

--- a/src/jujutracer.jl
+++ b/src/jujutracer.jl
@@ -35,5 +35,7 @@ export ImageTracer
 include("shapes.jl")
 export SurfacePoint, HitRecord, Shape, Sphere, ray_interception, Plane, World
 
+include("brdf.jl")
+export Material, UniformPigment, CheckeredPigment, DiffusiveBRDF, Eval
 
 end # module jujutracer

--- a/src/jujutracer.jl
+++ b/src/jujutracer.jl
@@ -38,4 +38,6 @@ export UniformPigment, CheckeredPigment, ImagePigment, DiffusiveBRDF, Material
 include("shapes.jl")
 export SurfacePoint, HitRecord, AbstractShape, Sphere, ray_intersection, Plane, World, Eval
 
+include("renderer.jl")
+export OnOff, Flat
 end # module jujutracer

--- a/src/jujutracer.jl
+++ b/src/jujutracer.jl
@@ -36,6 +36,6 @@ include("shapes.jl")
 export SurfacePoint, HitRecord, Shape, Sphere, ray_interception, Plane, World
 
 include("brdf.jl")
-export Material, UniformPigment, CheckeredPigment, DiffusiveBRDF, Eval
+export Material, UniformPigment, CheckeredPigment, ImagePigment, DiffusiveBRDF, Eval
 
 end # module jujutracer

--- a/src/renderer.jl
+++ b/src/renderer.jl
@@ -1,0 +1,41 @@
+#---------------------------------------------------------
+# OnOff
+#---------------------------------------------------------
+"""
+    OnOff(world::World)
+
+OnOff renderer of the scene. Returns white if the ray hits something, balck otherwise
+# Fields
+- `world::World` the world containing the scene
+# Functional Usage
+`OnOff(ray::Ray)` functional renderer on a ray
+"""
+struct OnOff <: Function
+    world::World
+end
+
+function (OF::OnOff)(ray::Ray)
+    repo = ray_intersection(OF.world, ray)
+    return (isnothing(repo)) ? RGB(0.0, 0.0, 0.0) : RGB(1.0, 1.0, 1.0)
+end
+
+#---------------------------------------------------------
+# Flat
+#---------------------------------------------------------
+"""
+    Flat(world::World)
+
+Flat renderer of the scene. Returns the Emition pigment of the hitten shapes
+# Fields
+- `world::World` the world containing the scene
+# Functional Usage
+`Flat(ray::Ray)` functional renderer on a ray
+"""
+struct Flat <: Function
+    world::World
+end
+
+function (F::Flat)(ray::Ray)
+    repo = ray_intersection(F.world, ray)
+    return (isnothing(repo)) ? RGB(0.0, 0.0, 0.0) : repo.shape.Mat.Emition(repo.surface_P)
+end

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -160,7 +160,7 @@ function ray_interception(pl::Plane, ray::Ray)
     d = inv_ray.dir
     
     if d != 0
-        t= -Oz\d.z
+        t= -Oz/d.z
         if t > inv_ray.tmin && t < inv_ray.tmax
             first_hit = t
         else

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -2,7 +2,7 @@
 # Shapes
 #---------------------------------------------------------
 """
-    abstract type Shape
+    abstract type AbstractShape
 
 Abstract type for all shapes.
 Made concrete by [`Sphere`](@ref) and [`Plane`](@ref).
@@ -174,7 +174,7 @@ function ray_intersection(pl::Plane, ray::Ray)
         surface_P = _plane_point_to_uv(hit_point),
         t = first_hit,
         ray = ray,
-        sphere = pl
+        shape = pl
     )
 end
 
@@ -260,9 +260,9 @@ struct HitRecord
     surface_P::SurfacePoint
     t::Float64
     ray::Ray
-    shape::Shape
+    shape::AbstractShape
 
-    function HitRecord(; world_P::Point, normal::Normal, surface_P::SurfacePoint, t::Float64, ray::Ray, shape::Shape)
+    function HitRecord(; world_P::Point, normal::Normal, surface_P::SurfacePoint, t::Float64, ray::Ray, shape::AbstractShape)
         new(world_P, normal, surface_P, t, ray, shape)
     end
 
@@ -295,12 +295,18 @@ function (C::CheckeredPigment)(p::SurfacePoint)
     x = floor(Int, p.u * C.col)
     y = floor(Int, p.v * C.row)
 
+    x = (x < C.col) ? x : C.col - 1
+    y = (y < C.row) ? y : C.row - 1
+
     return ((x + y) % 2 == 0) ? C.dark : C.bright
 end
 
 function (I::ImagePigment)(p::SurfacePoint)
     x = floor(Int, p.u * I.img.w)
     y = floor(Int, p.v * I.img.h)
+
+    x = (x < I.img.w) ? x : I.img.w - 1
+    y = (y < I.img.h) ? y : I.img.h - 1
 
     return I.img[x, y]
 end

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -1,45 +1,4 @@
 #---------------------------------------------------------
-# HitRecord
-#---------------------------------------------------------
-struct SurfacePoint
-    u::Float64
-    v::Float64
-end
-
-"""
-
-    HitRecord(world_point::Point, normal::Normal, surface_point::SurfacePoint, t::Float64, ray::Ray)
-
-Information about an intersection
-# Fields
-- `world_P::Point` the point in the world where the ray hit
-- `normal::Normal` the normal vector at the point of intersection
-- `surface_P::SurfacePoint` the point on the surface where the ray hit
-- `t::Float64` the distance from the ray origin to the hit point
-- `ray::Ray` the ray that hit the surface
-"""
-struct HitRecord
-    world_P::Point    
-    normal::Normal
-    surface_P::SurfacePoint
-    t::Float64
-    ray::Ray
-    shape::Shape
-
-    function HitRecord(; world_P::Point, normal::Normal, surface_P::SurfacePoint, t::Float64, ray::Ray, shape::Shape)
-        new(world_P, normal, surface_P, t, ray, shape)
-    end
-
-end
-
-Base.:≈(h1::HitRecord, h2::HitRecord) = h1.world_P ≈ h2.world_P && h1.normal ≈ h2.normal && h1.surface_P ≈ h2.surface_P && h1.t ≈ h2.t && h1.ray ≈ h2.ray
-Base.:≈(h::HitRecord, p::Point) = h.world_P ≈ p
-Base.:≈(h::HitRecord, s::SurfacePoint) = h.surface_P ≈ s
-Base.:≈(h::HitRecord, r::Ray) = h.ray ≈ r
-Base.:≈(s1::SurfacePoint, s2::SurfacePoint) = s1.u ≈ s2.u && s1.v ≈ s2.v
-
-
-#---------------------------------------------------------
 # Shapes
 #---------------------------------------------------------
 """
@@ -271,4 +230,75 @@ function ray_interception(W::World, ray::Ray)
     end
 
     return closest
+end
+
+#---------------------------------------------------------
+# HitRecord
+#---------------------------------------------------------
+struct SurfacePoint
+    u::Float64
+    v::Float64
+end
+
+"""
+
+    HitRecord(world_point::Point, normal::Normal, surface_point::SurfacePoint, t::Float64, ray::Ray)
+
+Information about an intersection
+# Fields
+- `world_P::Point` the point in the world where the ray hit
+- `normal::Normal` the normal vector at the point of intersection
+- `surface_P::SurfacePoint` the point on the surface where the ray hit
+- `t::Float64` the distance from the ray origin to the hit point
+- `ray::Ray` the ray that hit the surface
+"""
+struct HitRecord
+    world_P::Point    
+    normal::Normal
+    surface_P::SurfacePoint
+    t::Float64
+    ray::Ray
+    shape::Shape
+
+    function HitRecord(; world_P::Point, normal::Normal, surface_P::SurfacePoint, t::Float64, ray::Ray, shape::Shape)
+        new(world_P, normal, surface_P, t, ray, shape)
+    end
+
+end
+
+Base.:≈(h1::HitRecord, h2::HitRecord) = h1.world_P ≈ h2.world_P && h1.normal ≈ h2.normal && h1.surface_P ≈ h2.surface_P && h1.t ≈ h2.t && h1.ray ≈ h2.ray
+Base.:≈(h::HitRecord, p::Point) = h.world_P ≈ p
+Base.:≈(h::HitRecord, s::SurfacePoint) = h.surface_P ≈ s
+Base.:≈(h::HitRecord, r::Ray) = h.ray ≈ r
+Base.:≈(s1::SurfacePoint, s2::SurfacePoint) = s1.u ≈ s2.u && s1.v ≈ s2.v
+
+#---------------------------------------------------------
+# BRDF Methods
+#---------------------------------------------------------
+
+"""
+    Eval(BRDF::DiffusiveBRDF, normal::Normal, in_dir::Vec, out_dir::Vec, p::SurfacePoint)
+
+Return color of the diffused ray regarldless its icoming or outcoming direction
+"""
+function Eval(BRDF::DiffusiveBRDF, normal::Normal, in_dir::Vec, out_dir::Vec, p::SurfacePoint)
+    return BRDF.Pigment(p) * BRDF.R / π
+end 
+
+function (U::UniformPigment)(p::SurfacePoint)
+    return U.color
+end
+
+function (C::CheckeredPigment)(p::SurfacePoint)
+    x = floor(Int, p.u * C.col)
+    y = floor(Int, p.v * C.row)
+
+    return ((x + y) % 2 == 0) ? C.dark : C.bright
+end
+
+function (I::ImagePigment)(p::SurfacePoint)
+    x = floor(Int, p.u * I.img.w)
+    y = floor(Int, p.v * I.img.h)
+
+    return I.img[x, y]
 end

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -24,9 +24,10 @@ struct HitRecord
     surface_P::SurfacePoint
     t::Float64
     ray::Ray
+    shape::Shape
 
-    function HitRecord(; world_P::Point, normal::Normal, surface_P::SurfacePoint, t::Float64, ray::Ray)
-        new(world_P, normal, surface_P, t, ray)
+    function HitRecord(; world_P::Point, normal::Normal, surface_P::SurfacePoint, t::Float64, ray::Ray, shape::Shape)
+        new(world_P, normal, surface_P, t, ray, shape)
     end
 
 end
@@ -61,6 +62,7 @@ A sphere shape
 """
 struct Sphere <: Shape
     Tr::AbstractTransformation
+    Mat::Material
 end
 
 """
@@ -132,7 +134,8 @@ function ray_interception(S::Sphere, ray::Ray)
         normal = S.Tr(_sphere_normal(hit_point, ray.dir)),
         surface_P = _sphere_point_to_uv(hit_point),
         t = first_hit,
-        ray = ray
+        ray = ray,
+        shape = S
     )
 end
 
@@ -148,6 +151,7 @@ A plane shape
 """
 struct Plane <: Shape
     Tr::AbstractTransformation
+    Mat::Material
 end
 
 """
@@ -213,7 +217,8 @@ function ray_interception(pl::Plane, ray::Ray)
         normal = pl.Tr(_plane_normal(hit_point, ray.dir)),
         surface_P = _plane_point_to_uv(hit_point),
         t = first_hit,
-        ray = ray
+        ray = ray,
+        sphere = pl
     )
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -513,4 +513,27 @@ end
     @test pigment(SurfacePoint(1.0, 0.0)) ≈ color
     @test pigment(SurfacePoint(0.0, 1.0)) ≈ color
     @test pigment(SurfacePoint(1.0, 1.0)) ≈ color
+
+    img = hdrimg(2, 2)
+
+    img[0, 0] = RGB(1.0, 2.0, 3.0)
+    img[1, 0] = RGB(2.0, 3.0, 1.0)
+    img[0, 1] = RGB(2.0, 1.0, 3.0)
+    img[1, 1] = RGB(3.0, 2.0, 1.0)
+
+    pigment = ImagePigment(img)
+
+    @test pigment(SurfacePoint(0.0, 0.0)) ≈ RGB(1.0, 2.0, 3.0)
+    @test pigment(SurfacePoint(1.0, 0.0)) ≈ RGB(2.0, 3.0, 1.0)
+    @test pigment(SurfacePoint(0.0, 1.0)) ≈ RGB(2.0, 1.0, 3.0)
+    @test pigment(SurfacePoint(1.0, 1.0)) ≈ RGB(3.0, 2.0, 1.0)
+
+    color1 = RGB(1.0, 2.0, 3.0)
+    color2 = color1 * 10.0
+    pigment = CheckeredPigment(2, 2, color1, color2)
+
+    @test pigment(SurfacePoint(0.25, 0.25)) ≈ color1
+    @test pigment(SurfacePoint(0.75, 0.25)) ≈ color2
+    @test pigment(SurfacePoint(0.25, 0.75)) ≈ color2
+    @test pigment(SurfacePoint(0.75, 0.75)) ≈ color1
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -400,7 +400,10 @@ end
 
 @testset "Shapes" begin
     # test for sphere
-    S = Sphere(Transformation())
+    color = RGB(1.0, 2.0, 3.0)
+    pigment = UniformPigment(color)
+    Mat = Material(pigment, DiffusiveBRDF(pigment, 0.5))
+    S = Sphere(Transformation(), Mat)
     êz = Vec(0.0, 0.0, 1.0)
     êx = Vec(1.0, 0.0, 0.0)
 
@@ -429,7 +432,7 @@ end
     @test HR3.normal ≈ - Normal(êx)
 
     Tr = Translation(10.0, 0.0, 0.0)
-    S = Sphere(Tr)
+    S = Sphere(Tr, Mat)
     
     O4 = Tr(O1)
     ray4 = Ray(origin = O4, dir = -êz)
@@ -459,7 +462,7 @@ end
     o = Point(0.0, 1.0, 2.0)
     r = Ray(origin = o, dir = vec)
     a = Vec(0.0, 0.0, 1.0)
-    plane = Plane(Translation(a))
+    plane = Plane(Translation(a), Mat)
     HitRecord = ray_interception(plane, r)
     @test HitRecord.t ≈ 1.0
     @test HitRecord.world_P ≈ Point(1.0, 3.0, 1.0)
@@ -467,4 +470,14 @@ end
     @test HitRecord.surface_P.u ≈ 0.0
     @test HitRecord.surface_P.v ≈ 0.0
 
+end
+
+@testset "Pigment" begin
+    color = RGB(1.0, 2.0, 3.0)
+    pigment = UniformPigment(color)
+
+    @test pigment(SurfacePoint(0.0, 0.0)) ≈ color
+    @test pigment(SurfacePoint(1.0, 0.0)) ≈ color
+    @test pigment(SurfacePoint(0.0, 1.0)) ≈ color
+    @test pigment(SurfacePoint(1.0, 1.0)) ≈ color
 end


### PR DESCRIPTION
Implement structs and methods in order to implement a Flat Renderer. It will be necessary:
Pigment:
- [x] `AbstractPigment` and concrete pigment struct
- [x] `UniformPigment`
- [x] `CheckeredPigment`
- [x] `ImagePigment` (optional)

BRDF:
- [x] `AbstractBRDF`
- [x] `DiffusiveBRDF`
- [ ] `ReflectiveBRDF` (optional)

Other:
- [x] `Material`
- [x] Modify `Shape` and `HitRecord`
- [x] Modify `demo.jl`

Before merging remember:
- [x] docstrings
- [x] tests
- [x] README.md
- [x] CHANGELOG.md